### PR TITLE
Updated BoardTests to use areequal when using a collection assert

### DIFF
--- a/katas/gameoflife/dotnet-console/start/GameOfLife.Tests/BoardTests.cs
+++ b/katas/gameoflife/dotnet-console/start/GameOfLife.Tests/BoardTests.cs
@@ -38,7 +38,7 @@ namespace GameOfLife.Tests
                 { "*", "*", "*" },
                 { ".", ".", "." }
             });
-            CollectionAssert.AreEquivalent(
+            CollectionAssert.AreEqual(
                 new[,]
                 {
                     { ".", ".", "." },


### PR DESCRIPTION
Updated included unit test to use equals instead of equivalent. This will remove a needless barrier to an interviewee and should allow us to better use our time. 